### PR TITLE
Use latest Leiningen version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,12 @@ echo "done"
 
 # Determine Leiningen version
 if [ "$(grep ":min-lein-version[[:space:]]\+\"2" $BUILD_DIR/project.clj)" != "" ]; then
-  LEIN_VERSION="2.5.1"
+  # Get latest Leiningen version from the upstream bucket
+  LEIN_VERSION="$(curl --silent -L ${LATEST_LEIN_VERSION_URL})"
+  if [[ $LEIN_VERSION != [0-9]* ]]; then
+      # Fallback to latest known version
+      LEIN_VERSION="2.5.1"
+  fi
   LEIN_BIN_SOURCE="$(dirname $0)/../opt/lein2"
   if [ "$(grep :uberjar-name $BUILD_DIR/project.clj)" != "" ]; then
       LEIN_BUILD_TASK="${LEIN_BUILD_TASK:-uberjar}"

--- a/conf/cloudControl-env.properties
+++ b/conf/cloudControl-env.properties
@@ -1,2 +1,3 @@
 JVM_BUILDPACK_COMMON_URL="https://packages.${DOMAIN}/jvm-buildpack-common-43.tar.gz"
 CLOJURE_DIST_URL="https://packages.${DOMAIN}/buildpack-clojure"
+LATEST_LEIN_VERSION_URL="${CLOJURE_DIST_URL}/leiningen-latest"

--- a/etc/upload-latest-leiningen.sh
+++ b/etc/upload-latest-leiningen.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+# This script searches for the latest Leiningen release on
+# https://github.com/technomancy/leiningen and upload the
+# artifact to all configured buckets.
+
+# It's required to have gs3pload installed and configured
+# to execute this script. Please check https://github.com/fern4lvarez/gs3pload
+# for further information.
+
+if [ -z "$DOMAIN" ]; then
+    echo "Please set a DOMAIN var"
+    exit 1
+fi  
+
+LATEST_LEIN_VERSION_URL="https://packages.${DOMAIN}/buildpack-clojure/leiningen-latest"
+
+# Get current version of leiningen
+CURRENT="$(curl --silent -L ${LATEST_LEIN_VERSION_URL})"
+echo "---> Current version of leiningen: ${CURRENT}"
+
+# Get latest leiningen version and compare it with the current
+LATEST="$(curl --silent -I https://github.com/technomancy/leiningen/releases/latest | grep Location | sed 's#.*/##' |  tr -d '\r')"
+if [[ ${LATEST} < ${CURRENT} ]] || [[ ${LATEST} == ${CURRENT} ]]; then
+	echo "No newer version found. Exiting."
+	exit 1
+fi
+
+# Upload to buckets
+echo "---> Newer version found... ${LATEST}"
+FILENAME="leiningen-${LATEST}-standalone"
+echo ${LATEST} > leiningen-latest
+gs3pload push packages/buildpack-clojure leiningen-latest -p
+
+# Download the latest version and upload it to the bucket
+echo "---> Downloading leiningen version ${LATEST}..."
+wget https://github.com/technomancy/leiningen/releases/download/$LATEST/${FILENAME}.zip
+mv ${FILENAME}.zip ${FILENAME}.jar
+gs3pload push packages/buildpack-clojure ${FILENAME}.jar -p
+
+# Cleanup
+rm leiningen-latest
+rm ${FILENAME}.jar
+
+echo "Success! ${LATEST} version uploaded."


### PR DESCRIPTION
With `etc/upload-latest-leiningen.sh` script, we'll search for the
latest Leiningen version and upload it to all requirement buckets.

`compile` script will now look for this latest version and install it.
If no newer version was found, it will default a fixed stable version
(2.5.1 as of now).